### PR TITLE
Added Approval Gas Override

### DIFF
--- a/src/hooks/useApproveErc20.ts
+++ b/src/hooks/useApproveErc20.ts
@@ -21,7 +21,8 @@ export const useApproveErc20 = (
     const erc20 = new Contract(tokenAddress, ERC20, signer)
     const gasEstimate = await erc20.estimateGas.approve(spenderAddress, amountUnformatted)
     const overrides: Overrides = !!gasEstimate ? { gasLimit: gasEstimate.mul(12).div(10) } : undefined
-    return erc20.approve(spenderAddress, amountUnformatted, overrides)
+    if (!!overrides) return erc20.approve(spenderAddress, amountUnformatted, overrides)
+    return erc20.approve(spenderAddress, amountUnformatted)
   }
 
   return () =>

--- a/src/hooks/useApproveErc20.ts
+++ b/src/hooks/useApproveErc20.ts
@@ -1,7 +1,7 @@
 import { SendTransactionOptions } from '../interfaces'
 import { useSendTransaction } from './useSendTransaction'
 import ERC20 from '../abis/ERC20'
-import { BigNumber, Contract } from 'ethers'
+import { BigNumber, Contract, Overrides } from 'ethers'
 import { MaxUint256 } from '@ethersproject/constants'
 import { useSigner } from 'wagmi'
 
@@ -19,7 +19,9 @@ export const useApproveErc20 = (
   const callTransaction = async () => {
     const { data: signer } = await refetch()
     const erc20 = new Contract(tokenAddress, ERC20, signer)
-    return erc20.approve(spenderAddress, amountUnformatted)
+    const gasEstimate = await erc20.estimateGas.approve(spenderAddress, amountUnformatted)
+    const overrides: Overrides = !!gasEstimate ? { gasLimit: gasEstimate.mul(12).div(10) } : undefined
+    return erc20.approve(spenderAddress, amountUnformatted, overrides)
   }
 
   return () =>


### PR DESCRIPTION
Added a simple +20% to gas estimates for approval transactions.

Tested this on the V4 UI app and the estimate now seems in line with the suggested value I get from Etherscan, for example (~72k gas).